### PR TITLE
advisory distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,14 @@ go run cmd/rddl-claim-service/main.go
 
 The distribution funcionality can also be triggered manually by passing the distribute flag:
 ```
-go run cmd/rddl-claim-service/main.go --distribute=true
+go run cmd/rddl-claim-service/main.go --distribute=advisories
 ```
+or
+```
+go run cmd/rddl-claim-service/main.go --distribute=validators
+```
+
+
 
 ## Configuration
 The service needs to be configured via the ```./app.toml``` file or environment variables. The defaults are

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The service can be executed via the following go command without having it previ
 go run cmd/rddl-claim-service/main.go
 ```
 
-The distribution funcionality can also be triggered manually by passing the distribute flag:
+The distribution functionality can also be triggered manually by passing the distribute flag:
 ```
 go run cmd/rddl-claim-service/main.go --distribute=advisories
 ```

--- a/config/advisory_set.go
+++ b/config/advisory_set.go
@@ -1,0 +1,12 @@
+package config
+
+import "github.com/rddl-network/distribution-service/model"
+
+func GetWeeklyAdvisoryDistribution() [1]model.Advisory {
+	return [1]model.Advisory{
+		{
+			Address: "VJLHinV6iAVSw7Mwx1yRe3jLT86pbjoygJRPNroXhcKxAmtX2EZZM4wAhW993umuquWG7wujcPXw98f9",
+			Amount:  9615.3846154,
+		},
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -21,6 +21,10 @@ confirmations={{ .Confirmations }}
 fund-address="{{ .FundAddress }}"
 asset="{{ .Asset }}"
 log-level="{{ .LogLevel }}"
+data-path="{{ .DataPath }}"
+advisory-cron="{{ .AdvisoryCron }}"
+testnet-mode="{{ .TestnetMode }}"
+testnet-address="{{ .TestnetAddress }}"
 `
 
 type Config struct {
@@ -37,6 +41,10 @@ type Config struct {
 	FundAddress       string `mapstructure:"fund-address"`
 	Asset             string `mapstructure:"asset"`
 	LogLevel          string `mapstructure:"log-level"`
+	DataPath          string `mapstructure:"data-path"`
+	AdvisoryCron      string `mapstructure:"advisory-cron"`
+	TestnetMode       bool   `mapstructure:"testnet-mode"`
+	TestnetAddress    string `mapstructure:"testnet-address"`
 }
 
 var (
@@ -60,6 +68,10 @@ func DefaultConfig() *Config {
 		FundAddress:       "",
 		Asset:             "7add40beb27df701e02ee85089c5bc0021bc813823fedb5f1dcb5debda7f3da9",
 		LogLevel:          log.ERROR,
+		DataPath:          "./data/",
+		AdvisoryCron:      "* * * * * *",
+		TestnetMode:       false,
+		TestnetAddress:    "",
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -25,9 +25,9 @@ data-path="{{ .DataPath }}"
 advisory-cron="{{ .AdvisoryCron }}"
 testnet-mode="{{ .TestnetMode }}"
 testnet-address="{{ .TestnetAddress }}"
-planetmint_blocks_per_day="{{.PlmntBlocksPerDay}}"
-planetmint_distribution_offset="{{.PlmntDistributionOffset}}"
-distribution_settlement_offset="{{.DistributionSettlementOffset}}"
+planetmint_blocks_per_day={{.PlmntBlocksPerDay}}
+planetmint_distribution_offset={{.PlmntDistributionOffset}}
+distribution_settlement_offset={{.DistributionSettlementOffset}}
 `
 
 type Config struct {

--- a/config/config.go
+++ b/config/config.go
@@ -25,8 +25,8 @@ data-path="{{ .DataPath }}"
 advisory-cron="{{ .AdvisoryCron }}"
 testnet-mode="{{ .TestnetMode }}"
 testnet-address="{{ .TestnetAddress }}"
-plmnt_blocks_per_day="{{.PlmntBlocksPerDay}}"
-plmnt_distribution_offset="{{.PlmntDistributionOffset}}"
+planetmint_blocks_per_day="{{.PlmntBlocksPerDay}}"
+planetmint_distribution_offset="{{.PlmntDistributionOffset}}"
 distribution_settlement_offset="{{.DistributionSettlementOffset}}"
 `
 
@@ -48,8 +48,8 @@ type Config struct {
 	AdvisoryCron                 string `mapstructure:"advisory-cron"`
 	TestnetMode                  bool   `mapstructure:"testnet-mode"`
 	TestnetAddress               string `mapstructure:"testnet-address"`
-	PlmntBlocksPerDay            int64  `mapstructure:"plmnt_blocks_per_day"`
-	PlmntDistributionOffset      int64  `mapstructure:"plmnt_distribution_offset"`
+	PlanetmintBlocksPerDay       int64  `mapstructure:"planetmint_blocks_per_day"`
+	PlanetmintDistributionOffset int64  `mapstructure:"planetmint_distribution_offset"`
 	DistributionSettlementOffset int64  `mapstructure:"distribution_settlement_offset"`
 }
 
@@ -78,8 +78,8 @@ func DefaultConfig() *Config {
 		AdvisoryCron:                 "* * * * * *",
 		TestnetMode:                  false,
 		TestnetAddress:               "",
-		PlmntBlocksPerDay:            3600,
-		PlmntDistributionOffset:      75,
+		PlanetmintBlocksPerDay:       3600,
+		PlanetmintDistributionOffset: 75,
 		DistributionSettlementOffset: 5,
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -25,26 +25,32 @@ data-path="{{ .DataPath }}"
 advisory-cron="{{ .AdvisoryCron }}"
 testnet-mode="{{ .TestnetMode }}"
 testnet-address="{{ .TestnetAddress }}"
+plmnt_blocks_per_day="{{.PlmntBlocksPerDay}}"
+plmnt_distribution_offset="{{.PlmntDistributionOffset}}"
+distribution_settlement_offset="{{.DistributionSettlementOffset}}"
 `
 
 type Config struct {
-	Wallet            string `mapstructure:"wallet"`
-	PlanetmintRPCHost string `mapstructure:"planetmint-rpc-host"`
-	R2PHost           string `mapstructure:"r2p-host"`
-	CertsPath         string `mapstructure:"certs-path"`
-	Cron              string `mapstructure:"cron"`
-	RPCHost           string `mapstructure:"rpc-host"`
-	RPCUser           string `mapstructure:"rpc-user"`
-	RPCPass           string `mapstructure:"rpc-pass"`
-	ShamirHost        string `mapstructure:"shamir-host"`
-	Confirmations     int    `mapstructure:"confirmations"`
-	FundAddress       string `mapstructure:"fund-address"`
-	Asset             string `mapstructure:"asset"`
-	LogLevel          string `mapstructure:"log-level"`
-	DataPath          string `mapstructure:"data-path"`
-	AdvisoryCron      string `mapstructure:"advisory-cron"`
-	TestnetMode       bool   `mapstructure:"testnet-mode"`
-	TestnetAddress    string `mapstructure:"testnet-address"`
+	Wallet                       string `mapstructure:"wallet"`
+	PlanetmintRPCHost            string `mapstructure:"planetmint-rpc-host"`
+	R2PHost                      string `mapstructure:"r2p-host"`
+	CertsPath                    string `mapstructure:"certs-path"`
+	Cron                         string `mapstructure:"cron"`
+	RPCHost                      string `mapstructure:"rpc-host"`
+	RPCUser                      string `mapstructure:"rpc-user"`
+	RPCPass                      string `mapstructure:"rpc-pass"`
+	ShamirHost                   string `mapstructure:"shamir-host"`
+	Confirmations                int    `mapstructure:"confirmations"`
+	FundAddress                  string `mapstructure:"fund-address"`
+	Asset                        string `mapstructure:"asset"`
+	LogLevel                     string `mapstructure:"log-level"`
+	DataPath                     string `mapstructure:"data-path"`
+	AdvisoryCron                 string `mapstructure:"advisory-cron"`
+	TestnetMode                  bool   `mapstructure:"testnet-mode"`
+	TestnetAddress               string `mapstructure:"testnet-address"`
+	PlmntBlocksPerDay            int64  `mapstructure:"plmnt_blocks_per_day"`
+	PlmntDistributionOffset      int64  `mapstructure:"plmnt_distribution_offset"`
+	DistributionSettlementOffset int64  `mapstructure:"distribution_settlement_offset"`
 }
 
 var (
@@ -55,23 +61,26 @@ var (
 // DefaultConfig returns distribution-service default config
 func DefaultConfig() *Config {
 	return &Config{
-		Wallet:            "dao",
-		PlanetmintRPCHost: "127.0.0.1:9090",
-		R2PHost:           "https://testnet-r2p.rddl.io",
-		CertsPath:         "./certs/",
-		Cron:              "* * * * * *",
-		RPCHost:           "localhost:18884",
-		RPCUser:           "user",
-		RPCPass:           "password",
-		ShamirHost:        "https://localhost:9091",
-		Confirmations:     10,
-		FundAddress:       "",
-		Asset:             "7add40beb27df701e02ee85089c5bc0021bc813823fedb5f1dcb5debda7f3da9",
-		LogLevel:          log.ERROR,
-		DataPath:          "./data/",
-		AdvisoryCron:      "* * * * * *",
-		TestnetMode:       false,
-		TestnetAddress:    "",
+		Wallet:                       "dao",
+		PlanetmintRPCHost:            "127.0.0.1:9090",
+		R2PHost:                      "https://testnet-r2p.rddl.io",
+		CertsPath:                    "./certs/",
+		Cron:                         "* * * * * *",
+		RPCHost:                      "localhost:18884",
+		RPCUser:                      "user",
+		RPCPass:                      "password",
+		ShamirHost:                   "https://localhost:9091",
+		Confirmations:                10,
+		FundAddress:                  "",
+		Asset:                        "7add40beb27df701e02ee85089c5bc0021bc813823fedb5f1dcb5debda7f3da9",
+		LogLevel:                     log.ERROR,
+		DataPath:                     "./data/",
+		AdvisoryCron:                 "* * * * * *",
+		TestnetMode:                  false,
+		TestnetAddress:               "",
+		PlmntBlocksPerDay:            3600,
+		PlmntDistributionOffset:      75,
+		DistributionSettlementOffset: 5,
 	}
 }
 

--- a/config/util.go
+++ b/config/util.go
@@ -36,7 +36,7 @@ func LoadConfig(path string) (cfg *Config, err error) {
 		cfg.DataPath = v.GetString("data-path")
 		cfg.AdvisoryCron = v.GetString("advisory-cron")
 		cfg.TestnetMode = v.GetBool("testnet-mode")
-		cfg.TestnetAddress = v.GetBool("testnet-address")
+		cfg.TestnetAddress = v.GetString("testnet-address")
 		return
 	}
 	log.Println("no config file found.")

--- a/config/util.go
+++ b/config/util.go
@@ -33,6 +33,10 @@ func LoadConfig(path string) (cfg *Config, err error) {
 		cfg.FundAddress = v.GetString("fund-address")
 		cfg.Asset = v.GetString("asset")
 		cfg.LogLevel = v.GetString("log-level")
+		cfg.DataPath = v.GetString("data-path")
+		cfg.AdvisoryCron = v.GetString("advisory-cron")
+		cfg.TestnetMode = v.GetBool("testnet-mode")
+		cfg.TestnetAddress = v.GetBool("testnet-address")
 		return
 	}
 	log.Println("no config file found.")

--- a/config/util.go
+++ b/config/util.go
@@ -37,8 +37,8 @@ func LoadConfig(path string) (cfg *Config, err error) {
 		cfg.AdvisoryCron = v.GetString("advisory-cron")
 		cfg.TestnetMode = v.GetBool("testnet-mode")
 		cfg.TestnetAddress = v.GetString("testnet-address")
-		cfg.PlmntBlocksPerDay = v.GetInt64("plmnt_blocks_per_day")
-		cfg.PlmntDistributionOffset = v.GetInt64("plmnt_distribution_offset")
+		cfg.PlanetmintBlocksPerDay = v.GetInt64("planetmint_blocks_per_day")
+		cfg.PlanetmintDistributionOffset = v.GetInt64("planetmint_distribution_offset")
 		cfg.DistributionSettlementOffset = v.GetInt64("distribution_settlement_offset")
 		return
 	}

--- a/config/util.go
+++ b/config/util.go
@@ -37,6 +37,9 @@ func LoadConfig(path string) (cfg *Config, err error) {
 		cfg.AdvisoryCron = v.GetString("advisory-cron")
 		cfg.TestnetMode = v.GetBool("testnet-mode")
 		cfg.TestnetAddress = v.GetString("testnet-address")
+		cfg.PlmntBlocksPerDay = v.GetInt64("plmnt_blocks_per_day")
+		cfg.PlmntDistributionOffset = v.GetInt64("plmnt_distribution_offset")
+		cfg.DistributionSettlementOffset = v.GetInt64("distribution_settlement_offset")
 		return
 	}
 	log.Println("no config file found.")

--- a/model/advisory.go
+++ b/model/advisory.go
@@ -1,0 +1,6 @@
+package model
+
+type Advisory struct {
+	Address string
+	Amount  float64
+}

--- a/service/advisory_distribution.go
+++ b/service/advisory_distribution.go
@@ -61,12 +61,10 @@ func (ds *DistributionService) DistributeToAdvisoriesOnce() (err error) {
 }
 
 func (ds *DistributionService) RunDistribution(currentBlockHeight int64, lastWrittenBlockHeight int64) (run bool) {
-	var blocksPerDay int64 = 3600
-	blocksPerWeek := blocksPerDay * 7
-	var distributionOffset int64 = 75
-	var distributionSettlementOffset int64 = 5
+	cfg := config.GetConfig()
+	blocksPerWeek := cfg.PlmntBlocksPerDay * 7
 
-	barrierToPass := lastWrittenBlockHeight + blocksPerWeek + distributionOffset + distributionSettlementOffset
+	barrierToPass := lastWrittenBlockHeight + blocksPerWeek + cfg.PlmntDistributionOffset + cfg.DistributionSettlementOffset
 
 	if currentBlockHeight >= barrierToPass {
 		run = true

--- a/service/advisory_distribution.go
+++ b/service/advisory_distribution.go
@@ -62,9 +62,9 @@ func (ds *DistributionService) DistributeToAdvisoriesOnce() (err error) {
 
 func (ds *DistributionService) RunDistribution(currentBlockHeight int64, lastWrittenBlockHeight int64) (run bool) {
 	cfg := config.GetConfig()
-	blocksPerWeek := cfg.PlmntBlocksPerDay * 7
+	blocksPerWeek := cfg.PlanetmintBlocksPerDay * 7
 
-	barrierToPass := lastWrittenBlockHeight + blocksPerWeek + cfg.PlmntDistributionOffset + cfg.DistributionSettlementOffset
+	barrierToPass := lastWrittenBlockHeight + blocksPerWeek + cfg.PlanetmintDistributionOffset + cfg.DistributionSettlementOffset
 
 	if currentBlockHeight >= barrierToPass {
 		run = true

--- a/service/advisory_distribution.go
+++ b/service/advisory_distribution.go
@@ -4,9 +4,12 @@ import (
 	"encoding/binary"
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/rddl-network/distribution-service/config"
+)
+
+const (
+	lastBlockHeightFileName = "lastBlockHeight.dat"
 )
 
 func (ds *DistributionService) DistributeToAdvisories() {
@@ -73,7 +76,8 @@ func (ds *DistributionService) RunDistribution(currentBlockHeight int64, lastWri
 }
 
 func (ds *DistributionService) ReadLastBlockHeight() (blockHeight int64, err error) {
-	filePath := filepath.Join(".", "data", "lastBlockHeight.dat")
+	cfg := config.GetConfig()
+	filePath := cfg.DataPath + lastBlockHeightFileName
 
 	// Open the file
 	file, err := os.Open(filePath)
@@ -94,14 +98,14 @@ func (ds *DistributionService) ReadLastBlockHeight() (blockHeight int64, err err
 }
 
 func (ds *DistributionService) WriteLastBlockHeight(blockHeight int64) error {
-	dataDir := filepath.Join(".", "data")
-	err := os.MkdirAll(dataDir, 0755)
+	cfg := config.GetConfig()
+	err := os.MkdirAll(cfg.DataPath, 0755)
 	if err != nil {
 		return fmt.Errorf("error creating data directory: %w", err)
 	}
 
 	// Construct the full path to the file
-	filePath := filepath.Join(dataDir, "lastBlockHeight.dat")
+	filePath := cfg.DataPath + lastBlockHeightFileName
 
 	// Open the file with write-only and create/truncate flags
 	file, err := os.Create(filePath)

--- a/service/advisory_distribution.go
+++ b/service/advisory_distribution.go
@@ -1,0 +1,120 @@
+package service
+
+import (
+	"encoding/binary"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/rddl-network/distribution-service/config"
+)
+
+func (ds *DistributionService) DistributeToAdvisories() {
+	// gather data
+	currentBlockHeight, err := ds.pmClient.GetBlockHeight()
+	if err != nil {
+		ds.logger.Error("error querying block height:", err.Error())
+		return
+	}
+	lastWrittenBlockHeight, err := ds.ReadLastBlockHeight()
+	if err != nil {
+		ds.logger.Error("error reading block height from file", err.Error())
+		return
+	}
+
+	runDistribution := ds.RunDistribution(currentBlockHeight, lastWrittenBlockHeight)
+	if !runDistribution {
+		ds.logger.Debug("don't run distribution")
+		return
+	}
+
+	err = ds.DistributeToAdvisoriesOnce()
+	if err != nil {
+		return
+	}
+
+	err = ds.WriteLastBlockHeight(currentBlockHeight)
+	if err != nil {
+		ds.logger.Error("error writing to block height file", err.Error())
+		return
+	}
+}
+
+func (ds *DistributionService) DistributeToAdvisoriesOnce() (err error) {
+	cfg := config.GetConfig()
+	distributions := config.GetWeeklyAdvisoryDistribution()
+	for _, distribution := range distributions {
+		address := distribution.Address
+		if cfg.TestnetMode {
+			address = cfg.TestnetAddress
+		}
+		err = ds.sendToAddress(address, distribution.Amount, cfg.Asset)
+		if err != nil {
+			err = fmt.Errorf("sending to address failed: %w", err)
+			return
+		}
+	}
+	return
+}
+
+func (ds *DistributionService) RunDistribution(currentBlockHeight int64, lastWrittenBlockHeight int64) (run bool) {
+	var blocksPerDay int64 = 3600
+	blocksPerWeek := blocksPerDay * 7
+	var distributionOffset int64 = 75
+	var distributionSettlementOffset int64 = 5
+
+	barrierToPass := lastWrittenBlockHeight + blocksPerWeek + distributionOffset + distributionSettlementOffset
+
+	if currentBlockHeight >= barrierToPass {
+		run = true
+	}
+
+	return
+}
+
+func (ds *DistributionService) ReadLastBlockHeight() (blockHeight int64, err error) {
+	filePath := filepath.Join(".", "data", "lastBlockHeight.dat")
+
+	// Open the file
+	file, err := os.Open(filePath)
+	if err != nil {
+		err = fmt.Errorf("error opening file: %w", err)
+		return
+	}
+	defer file.Close()
+
+	// Read the int64 value
+	err = binary.Read(file, binary.LittleEndian, &blockHeight)
+	if err != nil {
+		err = fmt.Errorf("error reading block height: %w", err)
+		return
+	}
+
+	return
+}
+
+func (ds *DistributionService) WriteLastBlockHeight(blockHeight int64) error {
+	dataDir := filepath.Join(".", "data")
+	err := os.MkdirAll(dataDir, 0755)
+	if err != nil {
+		return fmt.Errorf("error creating data directory: %w", err)
+	}
+
+	// Construct the full path to the file
+	filePath := filepath.Join(dataDir, "lastBlockHeight.dat")
+
+	// Open the file with write-only and create/truncate flags
+	file, err := os.Create(filePath)
+	if err != nil {
+		return fmt.Errorf("error creating file: %w", err)
+	}
+	defer file.Close()
+
+	// Write the int64 value
+	err = binary.Write(file, binary.LittleEndian, blockHeight)
+	if err != nil {
+		return fmt.Errorf("error writing block height: %w", err)
+	}
+
+	return nil
+}

--- a/service/advisory_distribution_test.go
+++ b/service/advisory_distribution_test.go
@@ -1,0 +1,61 @@
+package service_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	shamir "github.com/rddl-network/shamir-coordinator-service/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAdvisoryDistribution(t *testing.T) {
+	app, db, mocks := setupService(t)
+	defer db.Close()
+
+	mocks.shamirClientMock.EXPECT().SendTokens(gomock.Any(), "VJLHinV6iAVSw7Mwx1yRe3jLT86pbjoygJRPNroXhcKxAmtX2EZZM4wAhW993umuquWG7wujcPXw98f9", "9615.38461540", gomock.Any()).Times(1).Return(shamir.SendTokensResponse{}, nil)
+
+	app.DistributeToAdvisories()
+}
+
+func TestReadWriteLastBlockHeight(t *testing.T) {
+	app, db, _ := setupService(t)
+	defer db.Close()
+
+	_, err := app.ReadLastBlockHeight()
+	assert.NoError(t, err)
+
+	var testValue int64 = 20
+	err = app.WriteLastBlockHeight(testValue)
+	assert.NoError(t, err)
+
+	height, err := app.ReadLastBlockHeight()
+	assert.NoError(t, err)
+	assert.Equal(t, testValue, height)
+}
+
+type distRequest struct {
+	lastWrittenBlock   int64
+	currentBlockHeight int64
+	run                bool
+}
+
+func TestRunDistribution(t *testing.T) {
+	app, db, _ := setupService(t)
+	defer db.Close()
+	distRequests := []distRequest{
+		{0, 25280, true},
+		{0, 50560, true},
+		{0, 25200, false},
+		{25280, 25280, false},
+		{25280, 50560, true},
+		{25280, 75840, true},
+		{25280, 50500, false},
+		{25280, 25200, false},
+	}
+	for i, request := range distRequests {
+		fmt.Printf("Index: %d, Request: %+v\n", i, request)
+		result := app.RunDistribution(request.currentBlockHeight, request.lastWrittenBlock)
+		assert.Equal(t, request.run, result)
+	}
+}

--- a/service/advisory_distribution_test.go
+++ b/service/advisory_distribution_test.go
@@ -13,9 +13,23 @@ func TestAdvisoryDistribution(t *testing.T) {
 	app, db, mocks := setupService(t)
 	defer db.Close()
 
+	var testValue int64 = 50000
+	err := app.WriteLastBlockHeight(testValue)
+	assert.NoError(t, err)
+
+	mocks.shamirClientMock.EXPECT().SendTokens(gomock.Any(), "VJLHinV6iAVSw7Mwx1yRe3jLT86pbjoygJRPNroXhcKxAmtX2EZZM4wAhW993umuquWG7wujcPXw98f9", "9615.38461540", gomock.Any()).Times(1).Return(shamir.SendTokensResponse{}, nil)
+	mocks.pmClientMock.EXPECT().GetBlockHeight().Times(1).Return(int64(100000), nil)
+	app.DistributeToAdvisories()
+}
+
+func TestAdvisoryDistributionOnce(t *testing.T) {
+	app, db, mocks := setupService(t)
+	defer db.Close()
+
 	mocks.shamirClientMock.EXPECT().SendTokens(gomock.Any(), "VJLHinV6iAVSw7Mwx1yRe3jLT86pbjoygJRPNroXhcKxAmtX2EZZM4wAhW993umuquWG7wujcPXw98f9", "9615.38461540", gomock.Any()).Times(1).Return(shamir.SendTokensResponse{}, nil)
 
-	app.DistributeToAdvisories()
+	err := app.DistributeToAdvisoriesOnce()
+	assert.NoError(t, err)
 }
 
 func TestReadWriteLastBlockHeight(t *testing.T) {

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -6,12 +6,8 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/rddl-network/distribution-service/service"
 	"github.com/rddl-network/distribution-service/testutil"
-	"github.com/stretchr/testify/assert"
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/storage"
-
-	r2p "github.com/rddl-network/rddl-2-plmnt-service/types"
-	shamir "github.com/rddl-network/shamir-coordinator-service/types"
 )
 
 type Mocks struct {
@@ -41,45 +37,4 @@ func setupService(t *testing.T) (app *service.DistributionService, db *leveldb.D
 	mocks.shamirClientMock = shamirClientMock
 
 	return
-}
-
-func TestService(t *testing.T) {
-	app, db, mocks := setupService(t)
-	defer db.Close()
-
-	mocks.eClientMock.EXPECT().ListReceivedByAddress(gomock.Any(), gomock.Any()).Times(1).Return(testutil.TxDetails, nil)
-	mocks.pmClientMock.EXPECT().GetValidatorAddresses().Times(1).Return([]string{"valoper1", "valoper2"}, nil)
-	mocks.pmClientMock.EXPECT().GetValidatorDelegationAddresses("valoper1").Times(1).Return([]string{"val1"}, nil)
-	mocks.pmClientMock.EXPECT().GetValidatorDelegationAddresses("valoper2").Times(1).Return([]string{"val2"}, nil)
-	mocks.r2pClientMock.EXPECT().GetReceiveAddress(gomock.Any(), "val1").Times(1).Return(r2p.ReceiveAddressResponse{LiquidAddress: "liquid1"}, nil)
-	mocks.r2pClientMock.EXPECT().GetReceiveAddress(gomock.Any(), "val2").Times(1).Return(r2p.ReceiveAddressResponse{LiquidAddress: "liquid2"}, nil)
-	mocks.shamirClientMock.EXPECT().SendTokens(gomock.Any(), "liquid1", "5.00000000", gomock.Any()).Times(1).Return(shamir.SendTokensResponse{}, nil)
-	mocks.shamirClientMock.EXPECT().SendTokens(gomock.Any(), "liquid2", "5.00000000", gomock.Any()).Times(1).Return(shamir.SendTokensResponse{}, nil)
-
-	app.Distribute()
-}
-
-func TestServiceZeroDistribution(t *testing.T) {
-	app, db, mocks := setupService(t)
-	defer db.Close()
-
-	mocks.eClientMock.EXPECT().ListReceivedByAddress(gomock.Any(), gomock.Any()).Times(1).Return(testutil.TxZeroDetails, nil)
-	// the other mocks are not called : sanity check
-	mocks.pmClientMock.EXPECT().GetValidatorAddresses().Times(0)
-	mocks.pmClientMock.EXPECT().GetValidatorDelegationAddresses("valoper1").Times(0)
-	mocks.pmClientMock.EXPECT().GetValidatorDelegationAddresses("valoper2").Times(0)
-	mocks.r2pClientMock.EXPECT().GetReceiveAddress(gomock.Any(), "val1").Times(0)
-	mocks.r2pClientMock.EXPECT().GetReceiveAddress(gomock.Any(), "val2").Times(0)
-	mocks.shamirClientMock.EXPECT().SendTokens(gomock.Any(), "liquid1", "5.00000000", gomock.Any()).Times(0)
-	mocks.shamirClientMock.EXPECT().SendTokens(gomock.Any(), "liquid2", "5.00000000", gomock.Any()).Times(0)
-	app.Distribute()
-}
-
-// Using uint64 with at least 8 zeros appended indicating the shift from float string to uint representation
-func TestCalculateDistributionAmount(t *testing.T) {
-	amt := service.CalculateDistributionAmount(100000000, 1000000000)
-	assert.Equal(t, uint64(90000000), amt)
-
-	amt = service.CalculateDistributionAmount(0, 1000000000)
-	assert.Equal(t, uint64(100000000), amt)
 }

--- a/service/validator_distribution.go
+++ b/service/validator_distribution.go
@@ -1,0 +1,148 @@
+package service
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/planetmint/planetmint-go/util"
+	"github.com/rddl-network/distribution-service/config"
+)
+
+// Distributes 10% of received funds to all validators
+func (ds *DistributionService) DistributeToValidators() {
+	cfg := config.GetConfig()
+
+	distributionAmt, err := ds.getDistributionAmount()
+	if err != nil {
+		ds.logger.Error("msg", "Error while calculating distribution amount: "+err.Error())
+		return
+	}
+
+	if distributionAmt == 0 {
+		ds.logger.Error("msg", "No tokens to distribute.")
+		return
+	}
+
+	liquidAddresses, err := ds.getBeneficiaries()
+	if err != nil {
+		ds.logger.Error("msg", "Error while fetching beneficiary addresses: "+err.Error())
+		return
+	}
+
+	// CalculateShares
+	share, _ := ds.calculateShares(distributionAmt, uint64(len(liquidAddresses)))
+
+	// SendToAddresses
+	ds.logger.Info("msg", "sending tokens", "addresses", strings.Join(liquidAddresses, ","), "amount", distributionAmt, "share", share)
+	err = ds.sendToAddresses(liquidAddresses, share, cfg.Asset)
+	if err != nil {
+		ds.logger.Error("msg", "Error while sending to validators: "+err.Error())
+		return
+	}
+}
+
+func (ds *DistributionService) getDistributionAmount() (distributionAmt uint64, err error) {
+	received, err := ds.checkReceivedBalance()
+	if err != nil {
+		return
+	}
+
+	ds.logger.Debug("msg", "Reading last occurrence")
+	occurrence, err := ds.GetLastOccurrence()
+	if err != nil {
+		return
+	}
+
+	ds.logger.Debug("msg", "Storing current occurrence")
+	err = ds.StoreOccurrence(time.Now().Unix(), received)
+	if err != nil {
+		return
+	}
+
+	if occurrence == nil {
+		return CalculateValidatorDistributionAmount(0, received), nil
+	}
+
+	return CalculateValidatorDistributionAmount(occurrence.Amount, received), nil
+}
+
+// Checks for received asset on a given address
+func (ds *DistributionService) checkReceivedBalance() (received uint64, err error) {
+	cfg := config.GetConfig()
+	ds.logger.Info("msg", "checking received balance", "address", cfg.FundAddress, " asset", cfg.Asset)
+
+	confirmationString := strconv.Itoa(cfg.Confirmations)
+	txDetails, err := ds.eClient.ListReceivedByAddress(cfg.GetElementsURL(),
+		[]string{confirmationString, "false", "true", `"` + cfg.FundAddress + `"`, `"` + cfg.Asset + `"`},
+	)
+	if err != nil {
+		return 0, err
+	}
+
+	for _, txDetail := range txDetails {
+		received += util.RDDLToken2Uint(txDetail.Amount)
+	}
+
+	return
+}
+
+func (ds *DistributionService) getBeneficiaries() (addresses []string, err error) {
+	plmntAddresses, err := ds.getActiveValidatorAddresses()
+	if err != nil {
+		return nil, err
+	}
+
+	ds.logger.Info("msg", "fetching liquid receive addresses", "planetmintAddresses", strings.Join(plmntAddresses, ","))
+	return ds.getReceiveAddresses(plmntAddresses)
+}
+
+// getReceiveAddresses fetches receive addresses from the rddl-2-plmnt service
+func (ds *DistributionService) getReceiveAddresses(addresses []string) (receiveAddresses []string, err error) {
+	for _, address := range addresses {
+		receiveAddress, err := ds.r2pClient.GetReceiveAddress(context.Background(), address)
+		if err != nil {
+			return nil, err
+		}
+		receiveAddresses = append(receiveAddresses, receiveAddress.LiquidAddress)
+	}
+	return
+}
+
+// Gets all active validator addresses
+func (ds *DistributionService) getActiveValidatorAddresses() (addresses []string, err error) {
+	valAddresses, err := ds.pmClient.GetValidatorAddresses()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, address := range valAddresses {
+		delegationAddresses, err := ds.pmClient.GetValidatorDelegationAddresses(address)
+		if err != nil {
+			return nil, err
+		}
+		addresses = append(addresses, delegationAddresses...)
+	}
+
+	return
+}
+
+// Calculates share per given address
+func (ds *DistributionService) calculateShares(total uint64, numValidators uint64) (share uint64, remainder uint64) {
+	if numValidators == 0 {
+		return 0, total
+	}
+
+	share = total / numValidators
+	remainder = total % numValidators
+	return
+}
+
+func CalculateValidatorDistributionAmount(prev uint64, curr uint64) (distributionAmt uint64) {
+	if prev == 0 {
+		return curr / 100 * 10
+	}
+
+	return (curr - prev) / 100 * 10
+}

--- a/service/validator_distribution_test.go
+++ b/service/validator_distribution_test.go
@@ -1,0 +1,54 @@
+package service_test
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/rddl-network/distribution-service/service"
+	"github.com/rddl-network/distribution-service/testutil"
+	"github.com/stretchr/testify/assert"
+
+	r2p "github.com/rddl-network/rddl-2-plmnt-service/types"
+	shamir "github.com/rddl-network/shamir-coordinator-service/types"
+)
+
+func TestValidatorDistribution(t *testing.T) {
+	app, db, mocks := setupService(t)
+	defer db.Close()
+
+	mocks.eClientMock.EXPECT().ListReceivedByAddress(gomock.Any(), gomock.Any()).Times(1).Return(testutil.TxDetails, nil)
+	mocks.pmClientMock.EXPECT().GetValidatorAddresses().Times(1).Return([]string{"valoper1", "valoper2"}, nil)
+	mocks.pmClientMock.EXPECT().GetValidatorDelegationAddresses("valoper1").Times(1).Return([]string{"val1"}, nil)
+	mocks.pmClientMock.EXPECT().GetValidatorDelegationAddresses("valoper2").Times(1).Return([]string{"val2"}, nil)
+	mocks.r2pClientMock.EXPECT().GetReceiveAddress(gomock.Any(), "val1").Times(1).Return(r2p.ReceiveAddressResponse{LiquidAddress: "liquid1"}, nil)
+	mocks.r2pClientMock.EXPECT().GetReceiveAddress(gomock.Any(), "val2").Times(1).Return(r2p.ReceiveAddressResponse{LiquidAddress: "liquid2"}, nil)
+	mocks.shamirClientMock.EXPECT().SendTokens(gomock.Any(), "liquid1", "5.00000000", gomock.Any()).Times(1).Return(shamir.SendTokensResponse{}, nil)
+	mocks.shamirClientMock.EXPECT().SendTokens(gomock.Any(), "liquid2", "5.00000000", gomock.Any()).Times(1).Return(shamir.SendTokensResponse{}, nil)
+
+	app.DistributeToValidators()
+}
+
+func TestServiceZeroVaildatorDistribution(t *testing.T) {
+	app, db, mocks := setupService(t)
+	defer db.Close()
+
+	mocks.eClientMock.EXPECT().ListReceivedByAddress(gomock.Any(), gomock.Any()).Times(1).Return(testutil.TxZeroDetails, nil)
+	// the other mocks are not called : sanity check
+	mocks.pmClientMock.EXPECT().GetValidatorAddresses().Times(0)
+	mocks.pmClientMock.EXPECT().GetValidatorDelegationAddresses("valoper1").Times(0)
+	mocks.pmClientMock.EXPECT().GetValidatorDelegationAddresses("valoper2").Times(0)
+	mocks.r2pClientMock.EXPECT().GetReceiveAddress(gomock.Any(), "val1").Times(0)
+	mocks.r2pClientMock.EXPECT().GetReceiveAddress(gomock.Any(), "val2").Times(0)
+	mocks.shamirClientMock.EXPECT().SendTokens(gomock.Any(), "liquid1", "5.00000000", gomock.Any()).Times(0)
+	mocks.shamirClientMock.EXPECT().SendTokens(gomock.Any(), "liquid2", "5.00000000", gomock.Any()).Times(0)
+	app.DistributeToValidators()
+}
+
+// Using uint64 with at least 8 zeros appended indicating the shift from float string to uint representation
+func TestCalculateVaildatorDistributionAmount(t *testing.T) {
+	amt := service.CalculateValidatorDistributionAmount(100000000, 1000000000)
+	assert.Equal(t, uint64(90000000), amt)
+
+	amt = service.CalculateValidatorDistributionAmount(0, 1000000000)
+	assert.Equal(t, uint64(100000000), amt)
+}

--- a/testutil/planetmint_client_mocks.go
+++ b/testutil/planetmint_client_mocks.go
@@ -33,6 +33,21 @@ func (m *MockIPlanetmintClient) EXPECT() *MockIPlanetmintClientMockRecorder {
 	return m.recorder
 }
 
+// GetBlockHeight mocks base method.
+func (m *MockIPlanetmintClient) GetBlockHeight() (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBlockHeight")
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBlockHeight indicates an expected call of GetBlockHeight.
+func (mr *MockIPlanetmintClientMockRecorder) GetBlockHeight() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlockHeight", reflect.TypeOf((*MockIPlanetmintClient)(nil).GetBlockHeight))
+}
+
 // GetValidatorAddresses mocks base method.
 func (m *MockIPlanetmintClient) GetValidatorAddresses() ([]string, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
* separated distribution from service file into advisory and validator distributions

* more compact service file
* extended planetmint API about GetBlockHeight method using cosmos sdk/client/grpc/tmservice for that
* added advisory distribution: using a file to sync/store the last utilized height
* added cronjob for  advisory distribution (execute now and then, but is only executed if a certain height is reached)
* added the following envs: data path (store last executed bock height), advisory cron, testnet-mode, testnet-address